### PR TITLE
post 관련 pagination 구현

### DIFF
--- a/src/main/java/com/github/springboard/api/PostApiController.java
+++ b/src/main/java/com/github/springboard/api/PostApiController.java
@@ -9,6 +9,7 @@ import com.github.springboard.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -39,8 +40,26 @@ public class PostApiController {
         return result;
     }
 
+    @GetMapping("/api/posts/{id}/comments/count")
+    public Result<Integer> countComments(@PathVariable("id") Long postId) {
+        Result<Integer> result = new Result<>();
+
+        try {
+            int count = commentService.countByPostId(postId);
+            result.setSuccess(true);
+            result.setData(count);
+            result.setMessage("정상적으로 불러왔습니다.");
+        } catch (Exception e) {
+            result.setSuccess(false);
+            result.setData(null);
+            result.setMessage(e.getMessage());
+        }
+
+        return result;
+    }
+
     @GetMapping("/api/posts/{id}/comments")
-    public Result<Page<PostCommentDto>> readComments(@PathVariable("id") Long postId, Pageable pageable) {
+    public Result<Page<PostCommentDto>> readComments(@PathVariable("id") Long postId, @PageableDefault Pageable pageable) {
         Result<Page<PostCommentDto>> result = new Result<>();
 
         try {

--- a/src/main/java/com/github/springboard/repository/CommentQueryRepositoryImpl.java
+++ b/src/main/java/com/github/springboard/repository/CommentQueryRepositoryImpl.java
@@ -26,14 +26,14 @@ public class CommentQueryRepositoryImpl implements CommentQueryRepository {
                 .leftJoin(comment.member, member).fetchJoin()
                 .leftJoin(comment.children, new QComment("another")).fetchJoin()
                 .where(comment.post.id.eq(postId).and(comment.parent.isNull()))
-                .orderBy(comment.id.asc())
+                .orderBy(comment.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         JPAQuery<Comment> countQuery = queryFactory
                 .selectFrom(comment)
-                .where(comment.post.id.eq(postId));
+                .where(comment.post.id.eq(postId).and(comment.parent.isNull()));
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchCount);
     }

--- a/src/main/java/com/github/springboard/repository/CommentRepository.java
+++ b/src/main/java/com/github/springboard/repository/CommentRepository.java
@@ -9,4 +9,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, Comment
 
     List<Comment> findFirst6ByOrderByIdDesc();
 
+    int countByPostId(Long postId);
+
 }

--- a/src/main/java/com/github/springboard/service/CommentService.java
+++ b/src/main/java/com/github/springboard/service/CommentService.java
@@ -41,6 +41,10 @@ public class CommentService {
         return commentRepository.findFirst6ByOrderByIdDesc();
     }
 
+    public int countByPostId(Long postId) {
+        return commentRepository.countByPostId(postId);
+    }
+
     @Transactional
     public Long write(Long memberId, Long postId, String content, Long parentId) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/com/github/springboard/web/PostController.java
+++ b/src/main/java/com/github/springboard/web/PostController.java
@@ -41,6 +41,7 @@ public class PostController {
         Page<PostListDto> postPage = posts.map(PostListDto::new);
         model.addAttribute("member", member);
         model.addAttribute("posts", postPage.getContent());
+        model.addAttribute("currentPage", postPage.getNumber());
         model.addAttribute("totalPages", postPage.getTotalPages());
         return "posts/list";
     }

--- a/src/main/java/com/github/springboard/web/PostController.java
+++ b/src/main/java/com/github/springboard/web/PostController.java
@@ -16,10 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
@@ -74,14 +71,14 @@ public class PostController {
     public String read(
             @CurrentMember Member member,
             @PathVariable("id") Long postId,
+            @RequestParam(name = "cp", defaultValue = "1") Long commentPageNumber,
             Model model
     ) {
         Post post = postService.read(postId);
         postService.visit(postId);
         model.addAttribute("member", member);
-        model.addAttribute("currentMemberId", member != null ? member.getId() : null);
-        model.addAttribute("currentMemberUsername", member != null ? member.getUsername() : null);
         model.addAttribute("post", post);
+        model.addAttribute("commentPageNumber", commentPageNumber);
         return "posts/read";
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   profiles:
     active: local
@@ -17,6 +16,12 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 1000
+
+  data:
+    web:
+      pageable:
+        page-parameter: p
+        one-indexed-parameters: true
 
 logging:
   level:

--- a/src/main/resources/templates/fragments/pagination.html
+++ b/src/main/resources/templates/fragments/pagination.html
@@ -4,17 +4,17 @@
   <nav th:fragment="pagination(current, total)">
     <ul class="pagination justify-content-center">
       <li class="page-item" th:unless="${current < 10}">
-        <a class="page-link" th:href="@{/posts(page=${(current / 10) * 10})}">
+        <a class="page-link" th:href="@{/posts(p=${current - current % 10})}">
           <span>&laquo;</span>
         </a>
       </li>
-      <li th:each="p : ${#numbers.sequence((current / 10) * 10 + 1, T(Math).min(((current + 10) / 10) * 10, total))}"
+      <li th:each="p : ${#numbers.sequence(current - current % 10 + 1, T(Math).min(current - current % 10 + 10, total))}"
           th:class="${p == current + 1 ? 'page-item active' : 'page-item'}">
         <a class="page-link" th:href="@{/posts(p=${p})}" th:text="${p}"></a>
       </li>
-      <li class="page-item" th:if="${current < ((total - 1) / 10) * 10}">
-        <a class="page-link" th:href="@{/posts(p=${((current + 10) / 10) * 10 + 1})}">
-          <span aria-hidden="true">&raquo;</span>
+      <li class="page-item" th:if="${current < (total - 1) - (total - 1) % 10}">
+        <a class="page-link" th:href="@{/posts(p=${current - current % 10 + 11})}">
+          <span>&raquo;</span>
         </a>
       </li>
     </ul>

--- a/src/main/resources/templates/fragments/pagination.html
+++ b/src/main/resources/templates/fragments/pagination.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+  <nav th:fragment="pagination(current, total)">
+    <ul class="pagination justify-content-center">
+      <li class="page-item" th:unless="${current < 10}">
+        <a class="page-link" th:href="@{/posts(page=${(current / 10) * 10})}">
+          <span>&laquo;</span>
+        </a>
+      </li>
+      <li th:each="p : ${#numbers.sequence((current / 10) * 10 + 1, T(Math).min(((current + 10) / 10) * 10, total))}"
+          th:class="${p == current + 1 ? 'page-item active' : 'page-item'}">
+        <a class="page-link" th:href="@{/posts(p=${p})}" th:text="${p}"></a>
+      </li>
+      <li class="page-item" th:if="${current < ((total - 1) / 10) * 10}">
+        <a class="page-link" th:href="@{/posts(p=${((current + 10) / 10) * 10 + 1})}">
+          <span aria-hidden="true">&raquo;</span>
+        </a>
+      </li>
+    </ul>
+  </nav>
+</body>
+</html>

--- a/src/main/resources/templates/posts/list.html
+++ b/src/main/resources/templates/posts/list.html
@@ -69,6 +69,14 @@
         <button class="btn btn-dark" type="button" th:onclick="|location.href='@{/posts}'|">전체글</button>
       </div>
       <div class="col-5 m-auto">
+        <nav th:replace="/fragments/pagination :: pagination(current=${currentPage}, total=${totalPages})"></nav>
+      </div>
+      <div class="col-2">
+        <button class="btn btn-dark float-right" type="button" th:onclick="|location.href='@{/posts/write}'|">글쓰기</button>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-5 m-auto">
         <form th:object="${condition}">
           <div class="input-group">
             <div class="input-group-prepend">
@@ -85,9 +93,6 @@
             </div>
           </div>
         </form>
-      </div>
-      <div class="col-2">
-        <button class="btn btn-dark float-right" type="button" th:onclick="|location.href='@{/posts/write}'|">글쓰기</button>
       </div>
     </div>
     <div th:replace="/fragments/footer :: footer"></div>

--- a/src/main/resources/templates/posts/read.html
+++ b/src/main/resources/templates/posts/read.html
@@ -53,12 +53,12 @@
       <div class="col">
         <div class="float-right">
           <form th:action="|@{/posts/{id}/remove(id=${post.id})}|" method="post"
-                th:if="${post.member.username == currentMemberUsername}"
+                th:if="${post.member.username == (member == null ? null : member.username)}"
                 style="display: inline">
             <button class="btn btn-danger" type="submit">글삭제</button>
           </form>
           <button class="btn btn-info" type="button"
-                  th:if="${post.member.username == currentMemberUsername}"
+                  th:if="${post.member.username == (member == null ? null : member.username)}"
                   th:onclick="|location.href='@{/posts/{id}/edit(id=${post.id})}'|">글수정</button>
           <button class="btn btn-dark" type="button" th:onclick="|location.href='@{/posts/write}'|">글쓰기</button>
         </div>
@@ -69,10 +69,11 @@
   <script th:inline="javascript">
     /*<![CDATA[*/
     const postId = [[${post.id}]];
-    const memberId = [[${currentMemberId}]];
+    const memberId = [[${member == null ? null : member.id}]];
+    const commentPageNumber = [[${commentPageNumber}]];
     /*]]>*/
     $(document).ready(() => {
-      readComments(0);
+      readComments(commentPageNumber);
     });
 
     $(document).on('keypress', '#comment_input', e => {
@@ -146,12 +147,12 @@
       const list = $('#comment_list');
       const cmtCount = $('#comment_count');
       /*<![CDATA[*/
-        const username = [[${currentMemberUsername}]];
+        const username = [[${member == null ? null : member.username}]];
         /*]]>*/
 
       $.ajax({
         type:"GET",
-        url: "/api/posts/" + postId + "/comments?page=" + page,
+        url: "/api/posts/" + postId + "/comments?p=" + page,
       })
               .done(result => {
                 if (!result['success']) {
@@ -159,8 +160,9 @@
                 }
 
                 let html = "";
-                let count = result['data']['content']['length'];
-                $.each(result['data']['content'], (index, comment) => {
+                for (let i = result['data']['content']['length'] - 1; i >= 0; i--) {
+                  let comment = result['data']['content'][i];
+
                   html += `<div class="row">`;
                   html += `  <div class="col">`;
                   html += `    <div style="padding-inline: 0.5rem">`;
@@ -181,7 +183,8 @@
                   html += `  </div>`;
                   html += `</div>`;
                   html += `<hr/>`;
-                  count += comment['children']['length'];
+
+                  // Replies
                   $.each(comment['children'], (index, reply) => {
                     html += `<div class="row ml-4">`;
                     html += `  <div class="col">`;
@@ -201,13 +204,62 @@
                     html += `  </div>`;
                     html += `</div>`;
                     html += `<hr/>`;
-                  })
-                })
+                  });
+                }
+
+                // Pagination
+                const currentPage = result['data']['number'];
+                const totalPages = result['data']['totalPages'];
+                const firstPage = currentPage - currentPage % 10;
+
+                if (totalPages > 1) {
+                  html += `<div class="row">`;
+                  html += `    <div class="col-5 m-auto">`;
+                  html += `        <nav>`;
+                  html += `            <ul class="pagination justify-content-center">`;
+                  html += currentPage >= 10 ? `<li class="page-item">
+                                                 <a class="page-link" href="/posts/${postId}?cp=${currentPage - currentPage % 10}">
+                                                    <span>&laquo;</span>
+                                                 </a>
+                                             </li>` : ``;
+
+                  for (let p = firstPage + 1; p <= Math.min(firstPage + 10, totalPages); p++) {
+                    html += `              <li class="page-item ${p === currentPage + 1 ? 'active' : ''}">`;
+                    html += `                  <a class="page-link" href="/posts/${postId}?cp=${p}">${p}</a>`;
+                    html += `              </li>`;
+                  }
+
+                  html += currentPage < (totalPages - 1) - (totalPages - 1) % 10 ? `
+                                        <li class="page-item">
+                                                 <a class="page-link" href="/posts/${postId}?cp=${currentPage - currentPage % 10 + 11}">
+                                                    <span>&raquo;</span>
+                                                 </a>
+                                        </li>` : ``;
+                  html += `            </ul>`;
+                  html += `        </nav>`;
+                  html += `    </div>`;
+                  html += `</div>`;
+                }
+
                 list.html(html);
-                cmtCount.html(count);
               })
               .fail(() => {
                 return alert('댓글을 불러오지 못하였습니다.');
+              });
+
+      $.ajax({
+        type:"GET",
+        url: "/api/posts/" + postId + "/comments/count",
+      })
+              .done(result => {
+                if (!result['success']) {
+                  return alert(result['message']);
+                }
+
+                cmtCount.html(result['data']);
+              })
+              .fail(() => {
+                return alert('댓글 개수를 불러오지 못하였습니다.');
               });
     }
 
@@ -242,7 +294,7 @@
                   return alert(result['message']);
                 }
 
-                readComments(0);
+                readComments(1);
                 input.val("");
                 input.focus();
               })
@@ -273,7 +325,7 @@
                   return alert(result['message']);
               }
 
-              readComments(0);
+              readComments(commentPageNumber);
               alert("정상적으로 삭제되었습니다.");
           })
           .fail(() => {
@@ -313,7 +365,7 @@
                   return alert(result['message']);
                 }
 
-                readComments(0);
+                readComments(commentPageNumber);
                 input.val("");
                 input.focus();
               })

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,3 @@
-
 spring:
   profiles:
     active: test
@@ -17,6 +16,12 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 1000
+
+  data:
+    web:
+      pageable:
+        page-parameter: p
+        one-indexed-parameters: true
 
 logging:
   level:


### PR DESCRIPTION
post list view에서 기본적으로 10개의 게시물 당 1페이지씩으로 pagination을 적용하였고,
각 게시물 댓글 view 또한 10개의 부모댓글 당 1페이지씩으로 나누었습니다.
자식댓글은 페이징 처리 기준에 해당되지 않으므로 한 페이지당 댓글 수는 10개를 넘을 수 있습니다.

post의 page 변수는 p, comment의 page 변수는 post read 화면기준으로 cp로 설정하였습니다.